### PR TITLE
fixing bug in PlayerCanAttack

### DIFF
--- a/Risk.Game/Game.cs
+++ b/Risk.Game/Game.cs
@@ -179,7 +179,10 @@ namespace Risk.Game
             foreach (var territory in Board.Territories.Where(t => t.Owner == player && EnoughArmiesToAttack(t)))
             {
                 var neighbors = Board.GetNeighbors(territory);
-                return neighbors.Any(n => n.Owner != player);
+                if (neighbors.Any(n => n.Owner != player))
+                {
+                    return true;
+                }
             }
             return false;
         }


### PR DESCRIPTION
Before, it would say false if the player had any groups of 2 or more armies that were surrounded by only owned territories.